### PR TITLE
Prepare backend for Render deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,8 @@ For production environments, consider:
 3. Implement IP-based rate limiting
 4. Use a web application firewall (WAF)
 5. Regular security audits and penetration testing
+## Deployment on Render
+
+1. Create a PostgreSQL database on Render and copy the connection string.
+2. Set the `DATABASE_URL` environment variable in your service settings.
+3. Deploy using the provided `render.yaml` which installs dependencies from `backend/requirements.txt` and starts the app with Gunicorn.

--- a/backend/app.py
+++ b/backend/app.py
@@ -73,7 +73,6 @@ from audit import log_audit, audit_route
 from security_headers import add_security_headers
 from error_handlers import register_error_handlers
 import schemas
-import functions_framework
 
 
 # Configure proper CORS to allow frontend connections
@@ -1931,20 +1930,6 @@ def init_test_data():
         print(f"Error creating test data: {str(e)}")
         return jsonify({"error": str(e)}), 500
 
-@functions_framework.http
-def app(request):
-    """HTTP Cloud Function entry point."""
-    # This enables CORS for all requests
-    if request.method == 'OPTIONS':
-        # Handle preflight requests
-        headers = {
-            'Access-Control-Allow-Origin': '*',
-            'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
-            'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-            'Access-Control-Max-Age': '3600'
-        }
-        return ('', 204, headers)
-    
-    # Run the Flask application
-    return app.wsgi_app(request.environ, start_response)
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 8080)))
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,0 @@
-from flask import request
-import functions_framework
-from app import app as flask_app
-
-@functions_framework.http
-def app(request):
-    """HTTP Cloud Function that acts as a wrapper for the Flask app."""
-    return flask_app(request.environ, start_response)

--- a/backend/wsgi.py
+++ b/backend/wsgi.py
@@ -1,0 +1,4 @@
+from app import app
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 8080)))

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,6 @@
+services:
+  - type: web
+    name: zebrafish-backend
+    env: python
+    buildCommand: pip install -r backend/requirements.txt
+    startCommand: gunicorn backend.app:app


### PR DESCRIPTION
## Summary
- fix backend entrypoint to work with gunicorn
- remove Google Functions wrapper
- add `wsgi.py` and `render.yaml` for Render
- document Render deployment steps

## Testing
- `python -m py_compile backend/app.py backend/wsgi.py`

------
https://chatgpt.com/codex/tasks/task_e_6844a737e8f8832c96464950db57f0df