### PR TITLE
Prepare backend for Render deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,10 @@ For production environments, consider:
 3. Implement IP-based rate limiting
 4. Use a web application firewall (WAF)
 5. Regular security audits and penetration testing
+## Deployment on Render
+
+1. Create a PostgreSQL database on Render and copy the connection string.
+2. Set the `DATABASE_URL` environment variable in your service settings.
+3. Deploy using the provided `render.yaml` which installs dependencies from `backend/requirements.txt` and starts the app with `gunicorn app:app --chdir backend`.
+4. The app listens on the port specified by the `PORT` environment variable so Render can assign a port automatically.
+5. CORS is configured in the backend to allow requests from `https://zebrafishregistry.web.app` and `https://zebrafishregistry.firebaseapp.com`.

--- a/backend/config.py
+++ b/backend/config.py
@@ -29,8 +29,8 @@ app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 CORS(app, 
     resources={r"/api/*": {
         "origins": [
-            "http://localhost:3000",
-            "https://zebrafish-registry.web.app"  # Add your Firebase URL
+            "https://zebrafishregistry.web.app",
+            "https://zebrafishregistry.firebaseapp.com"
         ],
         "methods": ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
         "allow_headers": ["Content-Type", "Authorization", "X-CSRF-TOKEN", "X-CSRF-TOKEN-ID"],

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,0 @@
-from flask import request
-import functions_framework
-from app import app as flask_app
-
-@functions_framework.http
-def app(request):
-    """HTTP Cloud Function that acts as a wrapper for the Flask app."""
-    return flask_app(request.environ, start_response)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,15 +1,14 @@
-Flask==2.0.1
-flask-cors==3.0.10
-flask-jwt-extended==4.3.1
-flask-sqlalchemy==2.5.1  # NOT 1.4.23
-gunicorn==20.1.0
-firebase-admin==5.3.0
-functions-framework==3.0.0
-flask-migrate==3.1.0
-psycopg2-binary==2.9.3
-sqlalchemy==1.4.23  # This is the correct version for SQLAlchemy
-Werkzeug==2.0.1
-flask-limiter==1.4
+Flask>=2.2
+flask-cors>=3.0.10
+flask-jwt-extended>=4.3
+flask-sqlalchemy>=2.5.1
+gunicorn>=20.1.0
+firebase-admin>=5.3.0
+flask-migrate>=3.1.0
+psycopg2-binary>=2.9.3
+sqlalchemy>=1.4.23,<2
+Werkzeug>=2.0.1
+flask-limiter>=1.4
 stripe>=9.0.0
 requests>=2.31.0
 marshmallow>=3.20.0      # NEW

--- a/backend/wsgi.py
+++ b/backend/wsgi.py
@@ -1,0 +1,5 @@
+import os
+from app import app
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 8080)))

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,6 @@
+services:
+  - type: web
+    name: zebrafish-backend
+    env: python
+    buildCommand: pip install -r backend/requirements.txt
+    startCommand: gunicorn app:app --chdir backend


### PR DESCRIPTION
## Summary
- fix backend entrypoint to work with gunicorn
- remove Google Functions wrapper
- add `wsgi.py` and `render.yaml` for Render
- document Render deployment steps
- relax backend requirement pins
- fix Render config and wsgi
- configure CORS for Firebase hosted frontend

## Testing
- `python -m py_compile backend/app.py backend/wsgi.py`
- `pip install -r backend/requirements.txt`
- `gunicorn app:app --chdir backend -b 127.0.0.1:8000`

------
https://chatgpt.com/codex/tasks/task_e_6844a737e8f8832c96464950db57f0df